### PR TITLE
Rhubarb for BitBucket

### DIFF
--- a/autoload/rhubarb.vim
+++ b/autoload/rhubarb.vim
@@ -322,6 +322,11 @@ function! rhubarb#FugitiveUrl(...) abort
   let commit = opts.commit
   if get(opts, 'type', '') ==# 'tree' || opts.path =~# '/$'
     let url = substitute(root . '/tree/' . commit . '/' . path, '/$', '', 'g')
+  elseif get(opts, 'type', '') ==# 'src' || opts.path =~# '[^/]$'
+    let url = substitute(root . '/src/' . commit . '/' . path, '/$', '', 'g')
+    if get(opts, 'line2') > 0 && get(opts, 'line1') == opts.line2
+      let url .= '#lines-' . opts.line1
+    endif
   elseif get(opts, 'type', '') ==# 'blob' || opts.path =~# '[^/]$'
     let escaped_commit = substitute(commit, '#', '%23', 'g')
     let url = root . '/blob/' . escaped_commit . '/' . path


### PR DESCRIPTION
I came across tpope/vim-rhubarb#61 and thought "There's no way the lift
for this would be heavy". So I thought to give it a stab.

This is the introductory commit for supporting Bitbucket with Rhubarb.
One does not need to do any extranneous configuration changes to use
this. One just needs to have the github_enterprise_urls set to BitBucket

    g:github_enterprise_urls = ['https://bitbucket.org']

There are s few assumptions here.

- Bitbucket uses /src/ in place og GitHub's /blob/
- Bitbucket uses #lines- in place of Github's #L
